### PR TITLE
Add routerboard firmware update support with robust error handling

### DIFF
--- a/mu/config.py
+++ b/mu/config.py
@@ -15,6 +15,7 @@ class Config:
         self.port: int | None = None
         self.log_dir: str = ''
         self.delete_backup_after_download = False
+        self.update_firmware = False
         self.update_type = 'online'
         self.online_update_channel = 'stable'
         self.reboot_timeout = 240

--- a/mu/configmanager.py
+++ b/mu/configmanager.py
@@ -48,6 +48,7 @@ class ConfigManager:
         else:
             cfg.online_update_channel = gl.get('online_update_channel')
         cfg.update_type = gl.get('update_type')
+        cfg.update_firmware = gl.get('update_firmware', False)
 
         devs = data['devices']
         for dev in devs:
@@ -83,6 +84,11 @@ class ConfigManager:
                 update_type = cfg.update_type
             else:
                 update_type = 'online'
+            # Use update_firmware from device, global or False
+            if 'update_firmware' in dev:
+                update_firmware = dev['update_firmware']
+            else:
+                update_firmware = cfg.update_firmware
             # load packages if manual update type
             if update_type == 'manual':
                 packages = dev['packages']
@@ -101,6 +107,7 @@ class ConfigManager:
                 packages=packages,
             )
             new_device.online_update_channel = online_update_channel
+            new_device.update_firmware = update_firmware
             devices.append(new_device)
         return (devices, logger)
 

--- a/mu/device.py
+++ b/mu/device.py
@@ -41,6 +41,7 @@ class Device:
         self.logger = logger
         self.packages = packages
         self.online_update_channel = 'stable'
+        self.update_firmware = False
         self.client: paramiko.SSHClient | None = None
         self.identity = ''
         self.public_key_file: str | None = None
@@ -49,6 +50,12 @@ class Device:
         self.latest_version = 'unknown'
         self.version_info_str = f'installed: {self.installed_version}, ' +\
                                 f'available: {self.latest_version}'
+        self.current_firmware = 'unknown'
+        self.upgrade_firmware = 'unknown'
+        self.firmware_info_str = (
+            f'current firmware: {self.current_firmware}, '
+            f'upgrade firmware: {self.upgrade_firmware}'
+        )
 
     def _ssh_check(self) -> None:
         if not self.client:
@@ -165,6 +172,88 @@ class Device:
         self._ssh_check()
         self.refresh_update_info()
         return self.update_available
+
+    def refresh_firmware_info(self) -> None:
+        """
+        Fetch routerboard firmware versions and update firmware_info_str,
+        current_firmware, and upgrade_firmware properties.
+        """
+        self._ssh_check()
+        output = self.ssh_call('system routerboard print')
+        for line in output:
+            if 'current-firmware' in line:
+                parts = line.split(':', 1)
+                if len(parts) == 2:
+                    self.current_firmware = parts[1].strip()
+            elif 'upgrade-firmware' in line:
+                parts = line.split(':', 1)
+                if len(parts) == 2:
+                    self.upgrade_firmware = parts[1].strip()
+        self.firmware_info_str = (
+            f'current firmware: {self.current_firmware}, '
+            f'upgrade firmware: {self.upgrade_firmware}'
+        )
+
+    def get_firmware_update_available(self) -> bool:
+        """Returns True if a routerboard firmware upgrade is available."""
+        self._ssh_check()
+        self.refresh_firmware_info()
+        return self.current_firmware != self.upgrade_firmware
+
+    def firmware_update(self) -> bool:
+        """
+        Check if a routerboard firmware upgrade is available and perform it.
+        Reboots the device and reconnects if an upgrade is applied.
+        Returns True on success or when already up to date.
+        """
+        self._ssh_check()
+        self.refresh_firmware_info()
+        if self.current_firmware == self.upgrade_firmware:
+            self.logger.log(
+                'info',
+                self.name,
+                f'routerboard firmware up to date: {self.current_firmware}',
+                stdout=True,
+            )
+            return True
+        self.logger.log(
+            'info',
+            self.name,
+            f'routerboard firmware upgrade available: '
+            f'{self.current_firmware} -> {self.upgrade_firmware}',
+            stdout=True,
+        )
+        self._routerboard_upgrade()
+        if not self.reboot_and_wait():
+            return False
+        try:
+            self.ssh_connect()
+        except Exception:
+            self.logger.log(
+                'error',
+                self.name,
+                'failed to reconnect after firmware reboot',
+                stdout=True,
+            )
+            return False
+        self.refresh_firmware_info()
+        if self.current_firmware != self.upgrade_firmware:
+            self.logger.log(
+                'error',
+                self.name,
+                f'firmware upgrade may have failed: '
+                f'current={self.current_firmware}, '
+                f'upgrade={self.upgrade_firmware}',
+                stdout=True,
+            )
+            return False
+        self.logger.log(
+            'info',
+            self.name,
+            f'routerboard firmware updated: {self.current_firmware}',
+            stdout=True,
+        )
+        return True
 
     def reboot_and_wait(self, downgrade=False) -> bool:
         """
@@ -677,6 +766,11 @@ class Device:
         """Execute system reboot using ssh_call."""
         self._ssh_check()
         _ = self.ssh_call('system reboot\ny')
+
+    def _routerboard_upgrade(self) -> None:
+        """Schedule routerboard firmware upgrade for next boot."""
+        self._ssh_check()
+        _ = self.ssh_call('system routerboard upgrade')
 
     def _set_channel(self, channel: str) -> None:
         """Set channel on the device using ssh_call."""

--- a/mu/main.py
+++ b/mu/main.py
@@ -111,6 +111,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                         d.version_info_str,
                         stdout=True,
                     )
+                if d.update_firmware:
+                    d.refresh_firmware_info()
+                    logger.log(
+                        'info',
+                        d.name,
+                        d.firmware_info_str,
+                        stdout=True,
+                    )
             else:
                 if args.backup_only:
                     d.backup()
@@ -128,6 +136,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                             'No updates available.',
                             stdout=True,
                         )
+                    if d.update_firmware:
+                        if not d.firmware_update():
+                            logger.log(
+                                'error',
+                                d.name,
+                                'firmware update failed',
+                                stdout=True,
+                            )
 
             d.ssh_close()
         else:

--- a/sample.yaml
+++ b/sample.yaml
@@ -9,6 +9,7 @@ global: # global settings
     delete_backup_after_download: False # delete the backup file on the Mikrotik device once it's downloaded to backup_dir
     online_update_channel: stable # [stable, testing, development, long term]
     reboot_timeout: 200 # seconds, 240 is default
+    update_firmware: False # update routerboard firmware after RouterOS update if needed
 devices: # your fleet of Mikrotik devices
     -   name: main_router # mandatory, mainly for logging
         address: 192.168.1.1 # mandatory

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -19,6 +19,7 @@ def test_config_init():
         assert config.port is None
         assert config.log_dir == ''
         assert config.delete_backup_after_download is False
+        assert config.update_firmware is False
         assert config.update_type == 'online'
         assert config.online_update_channel == 'stable'
         assert config.reboot_timeout == 240
@@ -36,6 +37,7 @@ def test_config_without_private_key():
     assert config.port is None
     assert config.log_dir == ''
     assert config.delete_backup_after_download is False
+    assert config.update_firmware is False
     assert config.update_type == 'online'
     assert config.online_update_channel == 'stable'
     assert config.reboot_timeout == 240

--- a/tests/configmanager_test.py
+++ b/tests/configmanager_test.py
@@ -491,3 +491,71 @@ def test_check_config_file_correct(capsys):
         # print(f'{result=}')
         # captured = capsys.readouterr()
         assert result
+
+
+def _make_mock_data(extra_global=None, extra_device=None):
+    data = {
+        'global': {
+            'backup_dir': '/tmp/backup',
+            'private_key_file': '',
+            'username': 'user',
+            'log_dir': '/tmp/log',
+        },
+        'devices': [
+            {
+                'name': 'device1',
+                'address': '192.168.1.1',
+            },
+        ],
+    }
+    if extra_global:
+        data['global'].update(extra_global)
+    if extra_device:
+        data['devices'][0].update(extra_device)
+    return data
+
+
+def test_load_config_update_firmware_default():
+    mock_data = _make_mock_data()
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_firmware is False
+
+
+def test_load_config_update_firmware_global_true():
+    mock_data = _make_mock_data(extra_global={'update_firmware': True})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_firmware is True
+
+
+def test_load_config_update_firmware_device_overrides_global():
+    mock_data = _make_mock_data(
+        extra_global={'update_firmware': True},
+        extra_device={'update_firmware': False},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_firmware is False
+
+
+def test_load_config_update_firmware_device_true_global_false():
+    mock_data = _make_mock_data(
+        extra_global={'update_firmware': False},
+        extra_device={'update_firmware': True},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_firmware is True

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,13 +1,12 @@
 # import pathlib
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
 from mu.config import Config
 from mu.device import Device
 from mu.logger import Logger
-# from unittest.mock import mock_open
-# from unittest.mock import patch
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -54,3 +53,143 @@ def test_device_init(device):
     assert device.installed_version == 'unknown'
     assert device.latest_version == 'unknown'
     assert device.version_info_str == 'installed: unknown, available: unknown'
+    assert device.update_firmware is False
+    assert device.current_firmware == 'unknown'
+    assert device.upgrade_firmware == 'unknown'
+    assert device.firmware_info_str == (
+        'current firmware: unknown, upgrade firmware: unknown'
+    )
+
+
+@pytest.fixture
+def connected_device():
+    mock_conf = MagicMock(spec=Config)
+    mock_logger = MagicMock(spec=Logger)
+    dev = Device(
+        conf=mock_conf,
+        name='test-router',
+        address='192.168.1.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    dev.client = MagicMock()
+    return dev
+
+
+def test_refresh_firmware_info(connected_device):
+    routerboard_output = [
+        '       routerboard: yes',
+        '            model: RBmAPL-2nD',
+        '  current-firmware: 7.14.3',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        connected_device.refresh_firmware_info()
+    assert connected_device.current_firmware == '7.14.3'
+    assert connected_device.upgrade_firmware == '7.16'
+    assert connected_device.firmware_info_str == (
+        'current firmware: 7.14.3, upgrade firmware: 7.16'
+    )
+
+
+def test_refresh_firmware_info_up_to_date(connected_device):
+    routerboard_output = [
+        '       routerboard: yes',
+        '  current-firmware: 7.16',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        connected_device.refresh_firmware_info()
+    assert connected_device.current_firmware == '7.16'
+    assert connected_device.upgrade_firmware == '7.16'
+
+
+def test_get_firmware_update_available_true(connected_device):
+    routerboard_output = [
+        '  current-firmware: 7.14.3',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        assert connected_device.get_firmware_update_available() is True
+
+
+def test_get_firmware_update_available_false(connected_device):
+    routerboard_output = [
+        '  current-firmware: 7.16',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        assert connected_device.get_firmware_update_available() is False
+
+
+def test_firmware_update_already_up_to_date(connected_device):
+    routerboard_output = [
+        '  current-firmware: 7.16',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        result = connected_device.firmware_update()
+    assert result is True
+    connected_device.logger.log.assert_called_with(
+        'info',
+        'test-router',
+        'routerboard firmware up to date: 7.16',
+        stdout=True,
+    )
+
+
+def test_firmware_update_performs_upgrade(connected_device):
+    before_output = [
+        '  current-firmware: 7.14.3',
+        '  upgrade-firmware: 7.16',
+    ]
+    after_output = [
+        '  current-firmware: 7.16',
+        '  upgrade-firmware: 7.16',
+    ]
+    call_count = 0
+
+    def ssh_call_side_effect(cmd):
+        nonlocal call_count
+        if 'routerboard print' in cmd:
+            call_count += 1
+            return before_output if call_count == 1 else after_output
+        return []
+
+    with patch.object(
+        connected_device, 'ssh_call', side_effect=ssh_call_side_effect,
+    ):
+        with patch.object(
+            connected_device, 'reboot_and_wait', return_value=True,
+        ):
+            with patch.object(connected_device, 'ssh_connect'):
+                result = connected_device.firmware_update()
+    assert result is True
+    assert connected_device.current_firmware == '7.16'
+
+
+def test_firmware_update_reboot_timeout(connected_device):
+    routerboard_output = [
+        '  current-firmware: 7.14.3',
+        '  upgrade-firmware: 7.16',
+    ]
+    with patch.object(
+        connected_device, 'ssh_call', return_value=routerboard_output,
+    ):
+        with patch.object(
+            connected_device, 'reboot_and_wait', return_value=False,
+        ):
+            result = connected_device.firmware_update()
+    assert result is False


### PR DESCRIPTION
Introduces update_firmware flag (global + per-device) that triggers a routerboard firmware upgrade after RouterOS updates. Fixes several correctness issues found in review:

- Parse firmware versions with split(':', 1) + strip() to avoid IndexError on malformed/empty RouterOS output lines
- Wrap ssh_connect() after firmware reboot in try/except so a reconnect failure returns False instead of crashing the fleet run
- Verify current_firmware == upgrade_firmware after reboot before returning True, catching silent flash failures
- Check firmware_update() return value in main.py and log an error on failure so reboot timeouts are visible to the operator
- Remove redundant 'or False' in configmanager device fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routerboard firmware update capability for devices, including checking availability and performing upgrades.
  * New configuration option to enable firmware updates globally or per-device (defaults to disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->