### PR TITLE
Add comprehensive tests to bring coverage from 38% to 100%

### DIFF
--- a/tests/configmanager_extended_test.py
+++ b/tests/configmanager_extended_test.py
@@ -1,0 +1,232 @@
+"""
+Extended ConfigManager tests covering the load_config branches
+that are not reached by the pre-existing tests (which fail due to
+PermissionError on /path/to/log).  All tests here mock Logger so
+no filesystem access is required.
+"""
+from unittest.mock import mock_open
+from unittest.mock import patch
+
+import yaml
+
+from mu.configmanager import ConfigManager
+
+
+def _base_global(**extra):
+    g = {
+        'backup_dir': '/tmp/backup',
+        'private_key_file': '',
+        'username': 'global-user',
+        'log_dir': '/tmp/log',
+    }
+    g.update(extra)
+    return g
+
+
+def _make_data(global_opts=None, device_opts=None):
+    gl = _base_global(**(global_opts or {}))
+    dev = {'name': 'dev1', 'address': '10.0.0.1'}
+    dev.update(device_opts or {})
+    return {'global': gl, 'devices': [dev]}
+
+
+# ─── deprecated online_upgrade_channel ───────────────────────────────────────
+
+def test_load_config_deprecated_online_upgrade_channel(capsys):
+    mock_data = _make_data(
+        global_opts={'online_upgrade_channel': 'legacy'},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    captured = capsys.readouterr()
+    assert 'deprecated' in captured.out
+    assert devices[0].online_update_channel == 'legacy'
+
+
+# ─── username from device ────────────────────────────────────────────────────
+
+def test_load_config_username_from_device():
+    mock_data = _make_data(device_opts={'username': 'device-user'})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].username == 'device-user'
+
+
+# ─── username from global ────────────────────────────────────────────────────
+
+def test_load_config_username_from_global():
+    mock_data = _make_data()  # no username in device, global has 'global-user'
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].username == 'global-user'
+
+
+# ─── no username at all ──────────────────────────────────────────────────────
+
+def test_load_config_no_username_at_all(capsys):
+    mock_data = _make_data(global_opts={'username': ''})
+    # Remove username from global
+    mock_data['global'].pop('username', None)
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    captured = capsys.readouterr()
+    assert 'Username not specified' in captured.out
+    assert len(devices) == 0
+
+
+# ─── port from device ────────────────────────────────────────────────────────
+
+def test_load_config_port_from_device():
+    mock_data = _make_data(
+        global_opts={'port': 1000},
+        device_opts={'port': 2222},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].port == 2222
+
+
+# ─── port from global ────────────────────────────────────────────────────────
+
+def test_load_config_port_from_global():
+    mock_data = _make_data(global_opts={'port': 3333})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].port == 3333
+
+
+# ─── port default 22 ─────────────────────────────────────────────────────────
+
+def test_load_config_port_default():
+    mock_data = _make_data()  # no port anywhere
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].port == 22
+
+
+# ─── online_update_channel from device ───────────────────────────────────────
+
+def test_load_config_online_update_channel_from_device():
+    mock_data = _make_data(
+        global_opts={'online_update_channel': 'stable'},
+        device_opts={'online_update_channel': 'testing'},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].online_update_channel == 'testing'
+
+
+# ─── online_update_channel from global ───────────────────────────────────────
+
+def test_load_config_online_update_channel_from_global():
+    mock_data = _make_data(global_opts={'online_update_channel': 'long-term'})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].online_update_channel == 'long-term'
+
+
+# ─── online_update_channel default stable ────────────────────────────────────
+
+def test_load_config_online_update_channel_default():
+    mock_data = _make_data()  # no channel anywhere
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].online_update_channel == 'stable'
+
+
+# ─── update_type from device ─────────────────────────────────────────────────
+
+def test_load_config_update_type_from_device():
+    mock_data = _make_data(
+        global_opts={'update_type': 'online'},
+        device_opts={'update_type': 'manual', 'packages': ['pkg1']},
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_type == 'manual'
+
+
+# ─── update_type from global ─────────────────────────────────────────────────
+
+def test_load_config_update_type_from_global():
+    mock_data = _make_data(global_opts={'update_type': 'online'})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_type == 'online'
+
+
+# ─── update_type default online ──────────────────────────────────────────────
+
+def test_load_config_update_type_default():
+    mock_data = _make_data()  # no update_type anywhere
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].update_type == 'online'
+
+
+# ─── packages loaded for manual update_type ──────────────────────────────────
+
+def test_load_config_packages_for_manual_update():
+    mock_data = _make_data(
+        device_opts={
+            'update_type': 'manual',
+            'packages': ['pkg1.npk', 'pkg2.npk'],
+        },
+    )
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].packages == ['pkg1.npk', 'pkg2.npk']
+
+
+# ─── packages empty for online update_type ───────────────────────────────────
+
+def test_load_config_no_packages_for_online_update():
+    mock_data = _make_data(device_opts={'update_type': 'online'})
+    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
+        with patch('yaml.safe_load', return_value=mock_data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                devices, _ = cm.load_config()
+    assert devices[0].packages == []

--- a/tests/configmanager_extended_test.py
+++ b/tests/configmanager_extended_test.py
@@ -30,17 +30,21 @@ def _make_data(global_opts=None, device_opts=None):
     return {'global': gl, 'devices': [dev]}
 
 
+def _load_config(data):
+    with patch('builtins.open', mock_open(read_data=yaml.dump(data))):
+        with patch('yaml.safe_load', return_value=data):
+            with patch('mu.configmanager.Logger'):
+                cm = ConfigManager('dummy')
+                return cm.load_config()
+
+
 # ─── deprecated online_upgrade_channel ───────────────────────────────────────
 
 def test_load_config_deprecated_online_upgrade_channel(capsys):
     mock_data = _make_data(
         global_opts={'online_upgrade_channel': 'legacy'},
     )
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     captured = capsys.readouterr()
     assert 'deprecated' in captured.out
     assert devices[0].online_update_channel == 'legacy'
@@ -50,11 +54,7 @@ def test_load_config_deprecated_online_upgrade_channel(capsys):
 
 def test_load_config_username_from_device():
     mock_data = _make_data(device_opts={'username': 'device-user'})
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].username == 'device-user'
 
 
@@ -62,11 +62,7 @@ def test_load_config_username_from_device():
 
 def test_load_config_username_from_global():
     mock_data = _make_data()  # no username in device, global has 'global-user'
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].username == 'global-user'
 
 
@@ -74,13 +70,8 @@ def test_load_config_username_from_global():
 
 def test_load_config_no_username_at_all(capsys):
     mock_data = _make_data(global_opts={'username': ''})
-    # Remove username from global
     mock_data['global'].pop('username', None)
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     captured = capsys.readouterr()
     assert 'Username not specified' in captured.out
     assert len(devices) == 0
@@ -93,11 +84,7 @@ def test_load_config_port_from_device():
         global_opts={'port': 1000},
         device_opts={'port': 2222},
     )
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].port == 2222
 
 
@@ -105,11 +92,7 @@ def test_load_config_port_from_device():
 
 def test_load_config_port_from_global():
     mock_data = _make_data(global_opts={'port': 3333})
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].port == 3333
 
 
@@ -117,11 +100,7 @@ def test_load_config_port_from_global():
 
 def test_load_config_port_default():
     mock_data = _make_data()  # no port anywhere
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].port == 22
 
 
@@ -132,11 +111,7 @@ def test_load_config_online_update_channel_from_device():
         global_opts={'online_update_channel': 'stable'},
         device_opts={'online_update_channel': 'testing'},
     )
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].online_update_channel == 'testing'
 
 
@@ -144,11 +119,7 @@ def test_load_config_online_update_channel_from_device():
 
 def test_load_config_online_update_channel_from_global():
     mock_data = _make_data(global_opts={'online_update_channel': 'long-term'})
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].online_update_channel == 'long-term'
 
 
@@ -156,11 +127,7 @@ def test_load_config_online_update_channel_from_global():
 
 def test_load_config_online_update_channel_default():
     mock_data = _make_data()  # no channel anywhere
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].online_update_channel == 'stable'
 
 
@@ -171,11 +138,7 @@ def test_load_config_update_type_from_device():
         global_opts={'update_type': 'online'},
         device_opts={'update_type': 'manual', 'packages': ['pkg1']},
     )
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].update_type == 'manual'
 
 
@@ -183,11 +146,7 @@ def test_load_config_update_type_from_device():
 
 def test_load_config_update_type_from_global():
     mock_data = _make_data(global_opts={'update_type': 'online'})
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].update_type == 'online'
 
 
@@ -195,11 +154,7 @@ def test_load_config_update_type_from_global():
 
 def test_load_config_update_type_default():
     mock_data = _make_data()  # no update_type anywhere
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].update_type == 'online'
 
 
@@ -212,11 +167,7 @@ def test_load_config_packages_for_manual_update():
             'packages': ['pkg1.npk', 'pkg2.npk'],
         },
     )
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].packages == ['pkg1.npk', 'pkg2.npk']
 
 
@@ -224,9 +175,5 @@ def test_load_config_packages_for_manual_update():
 
 def test_load_config_no_packages_for_online_update():
     mock_data = _make_data(device_opts={'update_type': 'online'})
-    with patch('builtins.open', mock_open(read_data=yaml.dump(mock_data))):
-        with patch('yaml.safe_load', return_value=mock_data):
-            with patch('mu.configmanager.Logger'):
-                cm = ConfigManager('dummy')
-                devices, _ = cm.load_config()
+    devices, _ = _load_config(mock_data)
     assert devices[0].packages == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+from mu.config import Config
+from mu.device import Device
+from mu.logger import Logger
+
+
+@pytest.fixture
+def mock_conf():
+    conf = MagicMock(spec=Config)
+    conf.key = None
+    conf.reboot_timeout = 10
+    conf.backup_dir = pathlib.Path('/tmp/backups')
+    conf.delete_backup_after_download = False
+    return conf
+
+
+@pytest.fixture
+def disconnected_dev(mock_conf):
+    return Device(
+        conf=mock_conf,
+        name='router',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=MagicMock(spec=Logger),
+    )

--- a/tests/device_extended_test.py
+++ b/tests/device_extended_test.py
@@ -1,0 +1,986 @@
+import pathlib
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import paramiko
+import pytest
+
+from mu.config import Config
+from mu.device import Device
+from mu.logger import Logger
+
+
+@pytest.fixture
+def mock_conf():
+    conf = MagicMock(spec=Config)
+    conf.key = None
+    conf.reboot_timeout = 10
+    conf.backup_dir = pathlib.Path('/tmp/backups')
+    conf.delete_backup_after_download = False
+    return conf
+
+
+@pytest.fixture
+def dev(mock_conf):
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='router',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.client = MagicMock()
+    return d
+
+
+# ─── _ssh_check ──────────────────────────────────────────────────────────────
+
+def test_ssh_check_no_client_raises(mock_conf):
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.client = None
+    with pytest.raises(SystemExit):
+        d._ssh_check()
+
+
+# ─── ssh_call ────────────────────────────────────────────────────────────────
+
+def test_ssh_call_returns_lines(dev):
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = ['line1\n', 'line2\n']
+    dev.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = dev.ssh_call('some command')
+    assert result == ['line1', 'line2']
+
+
+def test_ssh_call_raises_on_exception(dev):
+    dev.client.exec_command.side_effect = Exception('boom')
+    with pytest.raises(Exception):
+        dev.ssh_call('cmd')
+
+
+# ─── ssh_close ───────────────────────────────────────────────────────────────
+
+def test_ssh_close_closes_client(dev):
+    saved_client = dev.client
+    dev.ssh_close()
+    saved_client.close.assert_called_once()
+    assert dev.client is None
+
+
+def test_ssh_close_no_client(mock_conf):
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.client = None
+    d.ssh_close()  # should not raise
+
+
+# ─── ssh_connect ─────────────────────────────────────────────────────────────
+
+def test_ssh_connect_with_key(mock_conf):
+    mock_conf.key = MagicMock()
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        with patch.object(d, '_get_identity', return_value='myrouter'):
+            d.ssh_connect()
+    assert d.identity == 'myrouter'
+    mock_client.connect.assert_called_once()
+
+
+def test_ssh_connect_without_key(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        with patch.object(d, '_get_identity', return_value='myrouter'):
+            d.ssh_connect()
+    mock_client.connect.assert_called_once()
+
+
+def test_ssh_connect_auth_exception(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = (
+            paramiko.AuthenticationException('fail')
+        )
+        with pytest.raises(paramiko.AuthenticationException):
+            d.ssh_connect()
+
+
+# ─── ssh_test ────────────────────────────────────────────────────────────────
+
+def test_ssh_test_success_with_key(mock_conf):
+    mock_conf.key = MagicMock()
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        result = d.ssh_test()
+    assert result is True
+    mock_client.close.assert_called_once()
+
+
+def test_ssh_test_success_without_key(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        result = d.ssh_test()
+    assert result is True
+
+
+def test_ssh_test_auth_exception_user_says_n(mock_conf):
+    mock_conf.key = None
+    mock_conf.public_key_file = None
+    mock_conf.public_key_owner = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = (
+            paramiko.AuthenticationException('fail')
+        )
+        with patch('builtins.input', return_value='n'):
+            with pytest.raises(SystemExit):
+                d.ssh_test()
+
+
+def test_ssh_test_auth_exception_user_says_y(mock_conf):
+    mock_conf.key = None
+    mock_conf.public_key_file = 'mykey.pub'
+    mock_conf.public_key_owner = 'owner'
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = (
+            paramiko.AuthenticationException('fail')
+        )
+        with patch('builtins.input', return_value='y'):
+            with patch('mu.device.UserRegistrator') as mock_ur_class:
+                mock_ur = MagicMock()
+                mock_ur.run.return_value = True
+                mock_ur_class.return_value = mock_ur
+                result = d.ssh_test()
+    assert result is True
+
+
+def test_ssh_test_auth_exception_device_has_public_key_file(mock_conf):
+    mock_conf.key = None
+    mock_conf.public_key_file = 'global_key.pub'
+    mock_conf.public_key_owner = 'owner'
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.public_key_file = 'device_key.pub'
+    d.public_key_owner = 'device_owner'
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = (
+            paramiko.AuthenticationException('fail')
+        )
+        with patch('builtins.input', return_value='y'):
+            with patch('mu.device.UserRegistrator') as mock_ur_class:
+                mock_ur = MagicMock()
+                mock_ur.run.return_value = True
+                mock_ur_class.return_value = mock_ur
+                result = d.ssh_test()
+    assert result is True
+
+
+def test_ssh_test_os_error(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = OSError('unreachable')
+        result = d.ssh_test()
+    assert result is False
+
+
+# ─── simple_ssh_test ─────────────────────────────────────────────────────────
+
+def test_simple_ssh_test_success_with_key(mock_conf):
+    mock_conf.key = MagicMock()
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        result = d.simple_ssh_test()
+    assert result is True
+
+
+def test_simple_ssh_test_success_without_key(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        result = d.simple_ssh_test()
+    assert result is True
+
+
+def test_simple_ssh_test_failure(mock_conf):
+    mock_conf.key = None
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = Exception('fail')
+        result = d.simple_ssh_test()
+    assert result is False
+
+
+# ─── backup ──────────────────────────────────────────────────────────────────
+
+def test_backup_success(dev):
+    dev.identity = 'myrouter'
+    dev.conf.delete_backup_after_download = False
+    saved_output = ['Configuration backup saved\r']
+    with patch.object(dev, 'ssh_call', return_value=saved_output):
+        with patch('mu.device.SCPClient') as mock_scp_class:
+            mock_scp = MagicMock()
+            mock_scp_class.return_value.__enter__ = MagicMock(
+                return_value=mock_scp,
+            )
+            mock_scp_class.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            with patch.object(pathlib.Path, 'mkdir'):
+                result = dev.backup()
+    assert result is True
+
+
+def test_backup_failure_message(dev):
+    dev.identity = 'myrouter'
+    with patch.object(dev, 'ssh_call', return_value=['some error output']):
+        with patch.object(pathlib.Path, 'mkdir'):
+            result = dev.backup()
+    assert result is False
+
+
+def test_backup_scp_exception(dev):
+    dev.identity = 'myrouter'
+    saved_output = ['Configuration backup saved\r']
+    with patch.object(dev, 'ssh_call', return_value=saved_output):
+        with patch('mu.device.SCPClient', side_effect=Exception('scp fail')):
+            with patch.object(pathlib.Path, 'mkdir'):
+                result = dev.backup()
+    assert result is False
+
+
+def test_backup_with_delete(dev):
+    dev.identity = 'myrouter'
+    dev.conf.delete_backup_after_download = True
+    saved_output = ['Configuration backup saved\r']
+    with patch.object(dev, 'ssh_call', return_value=saved_output):
+        with patch('mu.device.SCPClient') as mock_scp_class:
+            mock_scp = MagicMock()
+            mock_scp_class.return_value.__enter__ = MagicMock(
+                return_value=mock_scp,
+            )
+            mock_scp_class.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            with patch.object(pathlib.Path, 'mkdir'):
+                with patch.object(dev, '_delete_file') as mock_delete:
+                    result = dev.backup()
+    assert result is True
+    mock_delete.assert_called_once()
+
+
+# ─── exec_command ────────────────────────────────────────────────────────────
+
+def test_exec_command_prints_output(dev, capsys):
+    with patch.object(dev, 'ssh_call', return_value=['line1', 'line2']):
+        dev.exec_command('some cmd')
+    captured = capsys.readouterr()
+    assert 'line1' in captured.out
+    assert 'line2' in captured.out
+
+
+# ─── get_installed_packages ──────────────────────────────────────────────────
+
+def test_get_installed_packages_normal(dev):
+    output = [
+        'Columns: #, NAME, VERSION, SCHEDULED',
+        ' 0 routeros     7.15',
+        ' 1 wireless     7.15',
+    ]
+    with patch.object(dev, 'ssh_call', return_value=output):
+        result = dev.get_installed_packages()
+    assert 'routeros 7.15' in result
+    assert 'wireless 7.15' in result
+
+
+def test_get_installed_packages_empty_output(dev):
+    with patch.object(dev, 'ssh_call', return_value=['only one line']):
+        result = dev.get_installed_packages()
+    assert result == []
+
+
+# ─── get_update_available ────────────────────────────────────────────────────
+
+def test_get_update_available_true(dev):
+    with patch.object(dev, 'refresh_update_info'):
+        dev.update_available = True
+        result = dev.get_update_available()
+    assert result is True
+
+
+def test_get_update_available_false(dev):
+    with patch.object(dev, 'refresh_update_info'):
+        dev.update_available = False
+        result = dev.get_update_available()
+    assert result is False
+
+
+# ─── refresh_update_info ─────────────────────────────────────────────────────
+
+def test_refresh_update_info_new_version_available(dev):
+    dev.online_update_channel = 'stable'
+    output = [
+        '  installed-version: 7.14',
+        '  latest-version: 7.15',
+        '  status: New version is available',
+    ]
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'ssh_call', return_value=output):
+            dev.refresh_update_info()
+    assert dev.update_available is True
+    assert dev.installed_version == '7.14'
+    assert dev.latest_version == '7.15'
+
+
+def test_refresh_update_info_not_available(dev):
+    dev.online_update_channel = 'stable'
+    output = [
+        '  installed-version: 7.15',
+        '  latest-version: 7.15',
+        '  status: System is already up to date',
+    ]
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'ssh_call', return_value=output):
+            dev.refresh_update_info()
+    assert dev.update_available is False
+
+
+def test_refresh_update_info_downloaded_reboot(dev):
+    dev.online_update_channel = 'stable'
+    output = [
+        '  status: Downloaded, please reboot',
+    ]
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'ssh_call', return_value=output):
+            dev.refresh_update_info()
+    assert dev.update_available is False
+
+
+def test_refresh_update_info_channel_switch(dev):
+    dev.online_update_channel = 'testing'
+    output = [
+        '  installed-version: 7.14',
+        '  latest-version: 7.15',
+        '  status: New version is available',
+    ]
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'ssh_call', return_value=output):
+            with patch.object(dev, '_set_channel') as mock_set:
+                dev.refresh_update_info()
+    assert dev.update_available is True
+    # When update is available and channel was different:
+    # set channel to 'testing', then set back to 'stable' before returning
+    assert mock_set.call_count == 2
+
+
+def test_refresh_update_info_channel_switch_no_update(dev):
+    dev.online_update_channel = 'testing'
+    output = [
+        '  installed-version: 7.15',
+        '  latest-version: 7.15',
+        '  status: System is already up to date',
+    ]
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'ssh_call', return_value=output):
+            with patch.object(dev, '_set_channel') as mock_set:
+                dev.refresh_update_info()
+    assert dev.update_available is False
+    # Should have set and reset channel
+    assert mock_set.call_count == 2
+
+
+# ─── reboot_and_wait ─────────────────────────────────────────────────────────
+
+def test_reboot_and_wait_success(dev):
+    dev.conf.reboot_timeout = 30
+    with patch.object(dev, '_reboot'):
+        with patch.object(dev, 'simple_ssh_test', return_value=True):
+            with patch('time.sleep'):
+                result = dev.reboot_and_wait()
+    assert result is True
+
+
+def test_reboot_and_wait_downgrade(dev):
+    dev.conf.reboot_timeout = 30
+    with patch.object(dev, '_downgrade') as mock_downgrade:
+        with patch.object(dev, 'simple_ssh_test', return_value=True):
+            with patch('time.sleep'):
+                result = dev.reboot_and_wait(downgrade=True)
+    assert result is True
+    mock_downgrade.assert_called_once()
+
+
+def test_reboot_and_wait_timeout(dev):
+    dev.conf.reboot_timeout = 0
+    with patch.object(dev, '_reboot'):
+        with patch.object(dev, 'simple_ssh_test', return_value=False):
+            with patch('time.sleep'):
+                result = dev.reboot_and_wait()
+    assert result is False
+
+
+# ─── update (online) ─────────────────────────────────────────────────────────
+
+def test_update_online_same_channel(dev):
+    dev.update_type = 'online'
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, 'refresh_update_info'):
+            with patch.object(dev, '_online_update') as mock_online:
+                dev.update()
+    mock_online.assert_called_once()
+
+
+def test_update_online_different_channel(dev):
+    dev.update_type = 'online'
+    dev.online_update_channel = 'testing'
+    with patch.object(dev, '_get_channel', return_value='stable'):
+        with patch.object(dev, '_set_channel') as mock_set:
+            with patch.object(dev, 'refresh_update_info'):
+                with patch.object(dev, '_online_update'):
+                    with patch('time.sleep'):
+                        dev.update()
+    mock_set.assert_called_once_with('testing')
+
+
+def test_update_manual(dev):
+    dev.update_type = 'manual'
+    with patch.object(dev, 'get_installed_packages', return_value=[]):
+        with patch.object(dev, '_manual_update') as mock_manual:
+            dev.update()
+    mock_manual.assert_called_once()
+
+
+# ─── _online_update ──────────────────────────────────────────────────────────
+
+def test_online_update_not_available(dev):
+    dev.update_available = False
+    dev._online_update()
+    dev.logger.log.assert_called_with(
+        'info',
+        'router',
+        'update not available',
+        stdout=True,
+    )
+
+
+def test_online_update_download_success(dev):
+    dev.update_available = True
+    dev.version_info_str = 'installed: 7.14, available: 7.15'
+    with patch.object(dev, '_download_update', return_value=True):
+        with patch.object(dev, 'reboot_and_wait', return_value=True):
+            with patch.object(dev, 'ssh_connect'):
+                with patch.object(dev, 'refresh_update_info'):
+                    dev._online_update()
+
+
+def test_online_update_download_failure(dev):
+    dev.update_available = True
+    dev.version_info_str = 'installed: 7.14, available: 7.15'
+    with patch.object(dev, '_download_update', return_value=False):
+        dev._online_update()
+    dev.logger.log.assert_called_with(
+        'error',
+        'router',
+        'download not successful',
+        stdout=True,
+    )
+
+
+def test_online_update_reboot_fails(dev):
+    dev.update_available = True
+    dev.version_info_str = 'installed: 7.14, available: 7.15'
+    with patch.object(dev, '_download_update', return_value=True):
+        with patch.object(dev, 'reboot_and_wait', return_value=False):
+            dev._online_update()
+
+
+# ─── _download_update ────────────────────────────────────────────────────────
+
+def test_download_update_success(dev):
+    output = ['  status: Downloaded, please reboot']
+    with patch.object(dev, 'ssh_call', return_value=output):
+        result = dev._download_update()
+    assert result is True
+
+
+def test_download_update_failure(dev):
+    output = ['  status: Some other status']
+    with patch.object(dev, 'ssh_call', return_value=output):
+        result = dev._download_update()
+    assert result is False
+
+
+# ─── _manual_update ──────────────────────────────────────────────────────────
+
+def test_manual_update_no_packages(dev):
+    dev.packages = []
+    dev._manual_update()
+    dev.logger.log.assert_called_with(
+        'error',
+        'router',
+        'manual update selected but no packages provided',
+        stdout=True,
+    )
+
+
+def test_manual_update_package_not_exist(dev, tmp_path):
+    dev.packages = [str(tmp_path / 'routeros-7.15.npk')]
+    dev._manual_update()
+    # Should log error about file not existing
+    dev.logger.log.assert_called()
+
+
+def test_manual_update_success(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake pkg')
+    dev.packages = [str(pkg)]
+    installed = ['routeros 7.14']
+    with patch.object(dev, 'get_installed_packages', return_value=installed):
+        with patch.object(dev, '_upload_package', return_value=True):
+            with patch.object(dev, 'reboot_and_wait', return_value=True):
+                with patch.object(dev, 'ssh_connect'):
+                    with patch.object(dev, 'refresh_update_info'):
+                        dev._manual_update()
+    dev.logger.log.assert_called()
+
+
+def test_manual_update_upload_fails(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake pkg')
+    dev.packages = [str(pkg)]
+    installed = ['routeros 7.14']
+    with patch.object(dev, 'get_installed_packages', return_value=installed):
+        with patch.object(dev, '_upload_package', return_value=False):
+            dev._manual_update()
+    dev.logger.log.assert_called()
+
+
+def test_manual_update_downgrade(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.13.npk'
+    pkg.write_bytes(b'fake pkg')
+    dev.packages = [str(pkg)]
+    installed = ['routeros 7.15']
+    with patch.object(dev, 'get_installed_packages', return_value=installed):
+        with patch.object(dev, '_upload_package', return_value=True):
+            with patch.object(
+                dev, 'reboot_and_wait', return_value=True,
+            ) as mock_reboot:
+                with patch.object(dev, 'ssh_connect'):
+                    with patch.object(dev, 'refresh_update_info'):
+                        dev._manual_update()
+    # Should call reboot_and_wait with downgrade=True
+    mock_reboot.assert_called_once_with(downgrade=True)
+
+
+def test_manual_update_reboot_fails(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake pkg')
+    dev.packages = [str(pkg)]
+    installed = ['routeros 7.14']
+    with patch.object(dev, 'get_installed_packages', return_value=installed):
+        with patch.object(dev, '_upload_package', return_value=True):
+            with patch.object(dev, 'reboot_and_wait', return_value=False):
+                dev._manual_update()
+
+
+# ─── _get_identity ───────────────────────────────────────────────────────────
+
+def test_get_identity(dev):
+    with patch.object(dev, 'ssh_call', return_value=['name: myrouter']):
+        result = dev._get_identity()
+    assert result == 'myrouter'
+
+
+# ─── _get_channel ────────────────────────────────────────────────────────────
+
+def test_get_channel_found(dev):
+    with patch.object(dev, 'ssh_call', return_value=['  channel: stable']):
+        result = dev._get_channel()
+    assert result == 'stable'
+
+
+def test_get_channel_not_found(dev):
+    with patch.object(dev, 'ssh_call', return_value=['  something: else']):
+        result = dev._get_channel()
+    assert result == ''
+
+
+# ─── _set_channel ────────────────────────────────────────────────────────────
+
+def test_set_channel_success(dev):
+    with patch.object(dev, 'ssh_call', return_value=[]):
+        dev._set_channel('testing')
+
+
+def test_set_channel_syntax_error(dev):
+    # The check is 'syntax error' in output (list membership, not substring)
+    with patch.object(dev, 'ssh_call', return_value=['syntax error']):
+        dev._set_channel('bad-channel')
+    dev.logger.log.assert_called()
+
+
+# ─── _delete_file ────────────────────────────────────────────────────────────
+
+def test_delete_file(dev):
+    with patch.object(dev, 'ssh_call', return_value=[]) as mock_call:
+        dev._delete_file('myfile.backup')
+    mock_call.assert_called_with('file remove myfile.backup')
+
+
+# ─── _reboot ─────────────────────────────────────────────────────────────────
+
+def test_reboot(dev):
+    with patch.object(dev, 'ssh_call', return_value=[]) as mock_call:
+        dev._reboot()
+    mock_call.assert_called_with('system reboot\ny')
+
+
+# ─── _downgrade ──────────────────────────────────────────────────────────────
+
+def test_downgrade(dev):
+    with patch.object(dev, 'ssh_call', return_value=[]) as mock_call:
+        dev._downgrade()
+    mock_call.assert_called_with('system package downgrade\ny')
+
+
+# ─── _routerboard_upgrade ────────────────────────────────────────────────────
+
+def test_routerboard_upgrade(dev):
+    with patch.object(dev, 'ssh_call', return_value=[]) as mock_call:
+        dev._routerboard_upgrade()
+    mock_call.assert_called_with('system routerboard upgrade')
+
+
+# ─── _upload_package ─────────────────────────────────────────────────────────
+
+def test_upload_package_success(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake')
+    with patch('mu.device.SCPClient') as mock_scp_class:
+        mock_scp = MagicMock()
+        mock_scp_class.return_value.__enter__ = MagicMock(
+            return_value=mock_scp,
+        )
+        mock_scp_class.return_value.__exit__ = MagicMock(return_value=False)
+        result = dev._upload_package(pkg)
+    assert result is True
+
+
+def test_upload_package_failure(dev, tmp_path):
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake')
+    with patch('mu.device.SCPClient', side_effect=Exception('scp fail')):
+        result = dev._upload_package(pkg)
+    assert result is False
+
+
+# ─── firmware_update ─────────────────────────────────────────────────────────
+
+def test_firmware_update_reconnect_fails(dev):
+    dev.current_firmware = '7.14'
+    dev.upgrade_firmware = '7.16'
+    with patch.object(dev, 'refresh_firmware_info'):
+        with patch.object(dev, '_routerboard_upgrade'):
+            with patch.object(dev, 'reboot_and_wait', return_value=True):
+                with patch.object(
+                    dev, 'ssh_connect', side_effect=Exception('fail'),
+                ):
+                    result = dev.firmware_update()
+    assert result is False
+
+
+def test_firmware_update_still_different_after_reboot(dev):
+    call_count = {'n': 0}
+
+    def side_refresh():
+        call_count['n'] += 1
+        if call_count['n'] == 1:
+            dev.current_firmware = '7.14'
+            dev.upgrade_firmware = '7.16'
+        else:
+            # After reboot, still different (upgrade failed)
+            dev.current_firmware = '7.14'
+            dev.upgrade_firmware = '7.16'
+
+    with patch.object(dev, 'refresh_firmware_info', side_effect=side_refresh):
+        with patch.object(dev, '_routerboard_upgrade'):
+            with patch.object(dev, 'reboot_and_wait', return_value=True):
+                with patch.object(dev, 'ssh_connect'):
+                    result = dev.firmware_update()
+    assert result is False
+
+
+# ─── version_is_lower ────────────────────────────────────────────────────────
+
+def test_version_is_lower_major(dev):
+    assert dev.version_is_lower('6.99', '7.0') is True
+    assert dev.version_is_lower('7.0', '6.99') is False
+
+
+def test_version_is_lower_stable(dev):
+    assert dev.version_is_lower('7.14', '7.15') is True
+    assert dev.version_is_lower('7.15', '7.14') is False
+    assert dev.version_is_lower('7.15', '7.15') is False
+
+
+def test_version_is_lower_beta(dev):
+    assert dev.version_is_lower('7.15beta9', '7.15') is True
+    assert dev.version_is_lower('7.15', '7.15beta9') is False
+
+
+def test_version_is_lower_alpha_vs_stable(dev):
+    # alpha < stable (release)
+    assert dev.version_is_lower('7.15alpha1', '7.15') is True
+    assert dev.version_is_lower('7.15', '7.15alpha1') is False
+
+
+def test_version_is_lower_beta_vs_stable(dev):
+    # beta < stable (release)
+    assert dev.version_is_lower('7.15beta1', '7.15') is True
+    assert dev.version_is_lower('7.15', '7.15beta1') is False
+
+
+def test_version_is_lower_same_beta(dev):
+    assert dev.version_is_lower('7.15beta1', '7.15beta2') is True
+    assert dev.version_is_lower('7.15beta2', '7.15beta1') is False
+
+
+def test_version_is_lower_equal(dev):
+    assert dev.version_is_lower('7.15', '7.15') is False
+
+
+def test_version_is_lower_third_segment(dev):
+    assert dev.version_is_lower('7.15.1', '7.15.2') is True
+    assert dev.version_is_lower('7.15.2', '7.15.1') is False
+    assert dev.version_is_lower('7.15.1', '7.15.1') is False
+
+
+def test_version_is_lower_rc_in_a(dev):
+    # 'rc1' has alpha chars but not 'alpha'/'beta' -> extra='0' branch
+    assert dev.version_is_lower('7.15rc1', '7.16') is True
+
+
+def test_version_is_lower_rc_in_b(dev):
+    # 'rc1' has alpha chars but not 'alpha'/'beta' -> extra='0' branch
+    assert dev.version_is_lower('7.14', '7.15rc1') is True
+
+
+# ─── defensive client=None guard coverage ────────────────────────────────────
+
+def test_ssh_call_client_none_after_check(mock_conf):
+    """Cover line 392: raise when client is None despite _ssh_check pass."""
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.client = MagicMock()
+    with patch.object(d, '_ssh_check'):
+        d.client = None
+        with pytest.raises(Exception):
+            d.ssh_call('cmd')
+
+
+def test_upload_package_client_none_after_check(mock_conf, tmp_path):
+    """Cover line 792: raise when client is None despite _ssh_check pass."""
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    pkg = tmp_path / 'routeros-7.15.npk'
+    pkg.write_bytes(b'fake')
+    d.client = MagicMock()
+    with patch.object(d, '_ssh_check'):
+        d.client = None
+        result = d._upload_package(pkg)
+    assert result is False
+
+
+def test_backup_client_none_after_check(mock_conf):
+    """Cover line 112: raise when client is None inside backup try block."""
+    mock_logger = MagicMock(spec=Logger)
+    d = Device(
+        conf=mock_conf,
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=mock_logger,
+    )
+    d.identity = 'myrouter'
+    d.client = MagicMock()
+    backup_saved = ['Configuration backup saved\r']
+    with patch.object(d, '_ssh_check'):
+        with patch.object(d, 'ssh_call', return_value=backup_saved):
+            with patch.object(pathlib.Path, 'mkdir'):
+                d.client = None
+                result = d.backup()
+    assert result is False

--- a/tests/device_extended_test.py
+++ b/tests/device_extended_test.py
@@ -1,4 +1,5 @@
 import pathlib
+from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -10,19 +11,11 @@ from mu.device import Device
 from mu.logger import Logger
 
 
-@pytest.fixture
-def mock_conf():
-    conf = MagicMock(spec=Config)
-    conf.key = None
-    conf.reboot_timeout = 10
-    conf.backup_dir = pathlib.Path('/tmp/backups')
-    conf.delete_backup_after_download = False
-    return conf
+# mock_conf and disconnected_dev fixtures live in conftest.py
 
 
 @pytest.fixture
 def dev(mock_conf):
-    mock_logger = MagicMock(spec=Logger)
     d = Device(
         conf=mock_conf,
         name='router',
@@ -30,7 +23,7 @@ def dev(mock_conf):
         port=22,
         username='admin',
         update_type='online',
-        logger=mock_logger,
+        logger=MagicMock(spec=Logger),
     )
     d.client = MagicMock()
     return d
@@ -38,20 +31,9 @@ def dev(mock_conf):
 
 # ─── _ssh_check ──────────────────────────────────────────────────────────────
 
-def test_ssh_check_no_client_raises(mock_conf):
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
-    d.client = None
+def test_ssh_check_no_client_raises(disconnected_dev):
     with pytest.raises(SystemExit):
-        d._ssh_check()
+        disconnected_dev._ssh_check()
 
 
 # ─── ssh_call ────────────────────────────────────────────────────────────────
@@ -81,76 +63,37 @@ def test_ssh_close_closes_client(dev):
     assert dev.client is None
 
 
-def test_ssh_close_no_client(mock_conf):
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
-    d.client = None
-    d.ssh_close()  # should not raise
+def test_ssh_close_no_client(disconnected_dev):
+    disconnected_dev.ssh_close()  # should not raise
 
 
 # ─── ssh_connect ─────────────────────────────────────────────────────────────
 
-def test_ssh_connect_with_key(mock_conf):
-    mock_conf.key = MagicMock()
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_connect_with_key(disconnected_dev):
+    disconnected_dev.conf.key = MagicMock()
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        with patch.object(d, '_get_identity', return_value='myrouter'):
-            d.ssh_connect()
-    assert d.identity == 'myrouter'
+        with patch.object(
+            disconnected_dev, '_get_identity', return_value='myrouter',
+        ):
+            disconnected_dev.ssh_connect()
+    assert disconnected_dev.identity == 'myrouter'
     mock_client.connect.assert_called_once()
 
 
-def test_ssh_connect_without_key(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_connect_without_key(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        with patch.object(d, '_get_identity', return_value='myrouter'):
-            d.ssh_connect()
+        with patch.object(
+            disconnected_dev, '_get_identity', return_value='myrouter',
+        ):
+            disconnected_dev.ssh_connect()
     mock_client.connect.assert_called_once()
 
 
-def test_ssh_connect_auth_exception(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_connect_auth_exception(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
@@ -158,64 +101,32 @@ def test_ssh_connect_auth_exception(mock_conf):
             paramiko.AuthenticationException('fail')
         )
         with pytest.raises(paramiko.AuthenticationException):
-            d.ssh_connect()
+            disconnected_dev.ssh_connect()
 
 
 # ─── ssh_test ────────────────────────────────────────────────────────────────
 
-def test_ssh_test_success_with_key(mock_conf):
-    mock_conf.key = MagicMock()
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_test_success_with_key(disconnected_dev):
+    disconnected_dev.conf.key = MagicMock()
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        result = d.ssh_test()
+        result = disconnected_dev.ssh_test()
     assert result is True
     mock_client.close.assert_called_once()
 
 
-def test_ssh_test_success_without_key(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_test_success_without_key(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        result = d.ssh_test()
+        result = disconnected_dev.ssh_test()
     assert result is True
 
 
-def test_ssh_test_auth_exception_user_says_n(mock_conf):
-    mock_conf.key = None
-    mock_conf.public_key_file = None
-    mock_conf.public_key_owner = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_test_auth_exception_user_says_n(disconnected_dev):
+    disconnected_dev.conf.public_key_file = None
+    disconnected_dev.conf.public_key_owner = None
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
@@ -224,23 +135,12 @@ def test_ssh_test_auth_exception_user_says_n(mock_conf):
         )
         with patch('builtins.input', return_value='n'):
             with pytest.raises(SystemExit):
-                d.ssh_test()
+                disconnected_dev.ssh_test()
 
 
-def test_ssh_test_auth_exception_user_says_y(mock_conf):
-    mock_conf.key = None
-    mock_conf.public_key_file = 'mykey.pub'
-    mock_conf.public_key_owner = 'owner'
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_test_auth_exception_user_says_y(disconnected_dev):
+    disconnected_dev.conf.public_key_file = 'mykey.pub'
+    disconnected_dev.conf.public_key_owner = 'owner'
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
@@ -252,26 +152,15 @@ def test_ssh_test_auth_exception_user_says_y(mock_conf):
                 mock_ur = MagicMock()
                 mock_ur.run.return_value = True
                 mock_ur_class.return_value = mock_ur
-                result = d.ssh_test()
+                result = disconnected_dev.ssh_test()
     assert result is True
 
 
-def test_ssh_test_auth_exception_device_has_public_key_file(mock_conf):
-    mock_conf.key = None
-    mock_conf.public_key_file = 'global_key.pub'
-    mock_conf.public_key_owner = 'owner'
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
-    d.public_key_file = 'device_key.pub'
-    d.public_key_owner = 'device_owner'
+def test_ssh_test_auth_exception_device_has_public_key_file(disconnected_dev):
+    disconnected_dev.conf.public_key_file = 'global_key.pub'
+    disconnected_dev.conf.public_key_owner = 'owner'
+    disconnected_dev.public_key_file = 'device_key.pub'
+    disconnected_dev.public_key_owner = 'device_owner'
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
@@ -283,87 +172,44 @@ def test_ssh_test_auth_exception_device_has_public_key_file(mock_conf):
                 mock_ur = MagicMock()
                 mock_ur.run.return_value = True
                 mock_ur_class.return_value = mock_ur
-                result = d.ssh_test()
+                result = disconnected_dev.ssh_test()
     assert result is True
 
 
-def test_ssh_test_os_error(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_ssh_test_os_error(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
         mock_client.connect.side_effect = OSError('unreachable')
-        result = d.ssh_test()
+        result = disconnected_dev.ssh_test()
     assert result is False
 
 
 # ─── simple_ssh_test ─────────────────────────────────────────────────────────
 
-def test_simple_ssh_test_success_with_key(mock_conf):
-    mock_conf.key = MagicMock()
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_simple_ssh_test_success_with_key(disconnected_dev):
+    disconnected_dev.conf.key = MagicMock()
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        result = d.simple_ssh_test()
+        result = disconnected_dev.simple_ssh_test()
     assert result is True
 
 
-def test_simple_ssh_test_success_without_key(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_simple_ssh_test_success_without_key(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
-        result = d.simple_ssh_test()
+        result = disconnected_dev.simple_ssh_test()
     assert result is True
 
 
-def test_simple_ssh_test_failure(mock_conf):
-    mock_conf.key = None
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_simple_ssh_test_failure(disconnected_dev):
     with patch('paramiko.SSHClient') as mock_ssh_class:
         mock_client = MagicMock()
         mock_ssh_class.return_value = mock_client
         mock_client.connect.side_effect = Exception('fail')
-        result = d.simple_ssh_test()
+        result = disconnected_dev.simple_ssh_test()
     assert result is False
 
 
@@ -524,9 +370,7 @@ def test_refresh_update_info_channel_switch(dev):
             with patch.object(dev, '_set_channel') as mock_set:
                 dev.refresh_update_info()
     assert dev.update_available is True
-    # When update is available and channel was different:
-    # set channel to 'testing', then set back to 'stable' before returning
-    assert mock_set.call_count == 2
+    assert mock_set.call_args_list == [call('testing'), call('stable')]
 
 
 def test_refresh_update_info_channel_switch_no_update(dev):
@@ -541,8 +385,7 @@ def test_refresh_update_info_channel_switch_no_update(dev):
             with patch.object(dev, '_set_channel') as mock_set:
                 dev.refresh_update_info()
     assert dev.update_available is False
-    # Should have set and reset channel
-    assert mock_set.call_count == 2
+    assert mock_set.call_args_list == [call('testing'), call('stable')]
 
 
 # ─── reboot_and_wait ─────────────────────────────────────────────────────────
@@ -624,9 +467,11 @@ def test_online_update_download_success(dev):
     dev.version_info_str = 'installed: 7.14, available: 7.15'
     with patch.object(dev, '_download_update', return_value=True):
         with patch.object(dev, 'reboot_and_wait', return_value=True):
-            with patch.object(dev, 'ssh_connect'):
-                with patch.object(dev, 'refresh_update_info'):
+            with patch.object(dev, 'ssh_connect') as mock_connect:
+                with patch.object(dev, 'refresh_update_info') as mock_refresh:
                     dev._online_update()
+    mock_connect.assert_called_once()
+    mock_refresh.assert_called_once()
 
 
 def test_online_update_download_failure(dev):
@@ -647,7 +492,9 @@ def test_online_update_reboot_fails(dev):
     dev.version_info_str = 'installed: 7.14, available: 7.15'
     with patch.object(dev, '_download_update', return_value=True):
         with patch.object(dev, 'reboot_and_wait', return_value=False):
-            dev._online_update()
+            with patch.object(dev, 'ssh_connect') as mock_connect:
+                dev._online_update()
+    mock_connect.assert_not_called()
 
 
 # ─── _download_update ────────────────────────────────────────────────────────
@@ -680,10 +527,15 @@ def test_manual_update_no_packages(dev):
 
 
 def test_manual_update_package_not_exist(dev, tmp_path):
-    dev.packages = [str(tmp_path / 'routeros-7.15.npk')]
+    pkg = tmp_path / 'routeros-7.15.npk'
+    dev.packages = [str(pkg)]
     dev._manual_update()
-    # Should log error about file not existing
-    dev.logger.log.assert_called()
+    dev.logger.log.assert_called_with(
+        'error',
+        'router',
+        f'{pkg} does not exist',
+        stdout=True,
+    )
 
 
 def test_manual_update_success(dev, tmp_path):
@@ -694,10 +546,13 @@ def test_manual_update_success(dev, tmp_path):
     with patch.object(dev, 'get_installed_packages', return_value=installed):
         with patch.object(dev, '_upload_package', return_value=True):
             with patch.object(dev, 'reboot_and_wait', return_value=True):
-                with patch.object(dev, 'ssh_connect'):
-                    with patch.object(dev, 'refresh_update_info'):
+                with patch.object(dev, 'ssh_connect') as mock_connect:
+                    with patch.object(
+                        dev, 'refresh_update_info',
+                    ) as mock_refresh:
                         dev._manual_update()
-    dev.logger.log.assert_called()
+    mock_connect.assert_called_once()
+    mock_refresh.assert_called_once()
 
 
 def test_manual_update_upload_fails(dev, tmp_path):
@@ -708,7 +563,12 @@ def test_manual_update_upload_fails(dev, tmp_path):
     with patch.object(dev, 'get_installed_packages', return_value=installed):
         with patch.object(dev, '_upload_package', return_value=False):
             dev._manual_update()
-    dev.logger.log.assert_called()
+    dev.logger.log.assert_called_with(
+        'error',
+        'router',
+        f'failed to upload {pkg} to device',
+        stdout=True,
+    )
 
 
 def test_manual_update_downgrade(dev, tmp_path):
@@ -724,7 +584,6 @@ def test_manual_update_downgrade(dev, tmp_path):
                 with patch.object(dev, 'ssh_connect'):
                     with patch.object(dev, 'refresh_update_info'):
                         dev._manual_update()
-    # Should call reboot_and_wait with downgrade=True
     mock_reboot.assert_called_once_with(downgrade=True)
 
 
@@ -736,7 +595,9 @@ def test_manual_update_reboot_fails(dev, tmp_path):
     with patch.object(dev, 'get_installed_packages', return_value=installed):
         with patch.object(dev, '_upload_package', return_value=True):
             with patch.object(dev, 'reboot_and_wait', return_value=False):
-                dev._manual_update()
+                with patch.object(dev, 'ssh_connect') as mock_connect:
+                    dev._manual_update()
+    mock_connect.assert_not_called()
 
 
 # ─── _get_identity ───────────────────────────────────────────────────────────
@@ -769,7 +630,6 @@ def test_set_channel_success(dev):
 
 
 def test_set_channel_syntax_error(dev):
-    # The check is 'syntax error' in output (list membership, not substring)
     with patch.object(dev, 'ssh_call', return_value=['syntax error']):
         dev._set_channel('bad-channel')
     dev.logger.log.assert_called()
@@ -850,13 +710,8 @@ def test_firmware_update_still_different_after_reboot(dev):
 
     def side_refresh():
         call_count['n'] += 1
-        if call_count['n'] == 1:
-            dev.current_firmware = '7.14'
-            dev.upgrade_firmware = '7.16'
-        else:
-            # After reboot, still different (upgrade failed)
-            dev.current_firmware = '7.14'
-            dev.upgrade_firmware = '7.16'
+        dev.current_firmware = '7.14'
+        dev.upgrade_firmware = '7.16'
 
     with patch.object(dev, 'refresh_firmware_info', side_effect=side_refresh):
         with patch.object(dev, '_routerboard_upgrade'):
@@ -868,119 +723,72 @@ def test_firmware_update_still_different_after_reboot(dev):
 
 # ─── version_is_lower ────────────────────────────────────────────────────────
 
-def test_version_is_lower_major(dev):
-    assert dev.version_is_lower('6.99', '7.0') is True
-    assert dev.version_is_lower('7.0', '6.99') is False
+@pytest.fixture(scope='module')
+def version_dev():
+    return Device(
+        conf=MagicMock(spec=Config),
+        name='r',
+        address='10.0.0.1',
+        port=22,
+        username='admin',
+        update_type='online',
+        logger=MagicMock(spec=Logger),
+    )
 
 
-def test_version_is_lower_stable(dev):
-    assert dev.version_is_lower('7.14', '7.15') is True
-    assert dev.version_is_lower('7.15', '7.14') is False
-    assert dev.version_is_lower('7.15', '7.15') is False
-
-
-def test_version_is_lower_beta(dev):
-    assert dev.version_is_lower('7.15beta9', '7.15') is True
-    assert dev.version_is_lower('7.15', '7.15beta9') is False
-
-
-def test_version_is_lower_alpha_vs_stable(dev):
-    # alpha < stable (release)
-    assert dev.version_is_lower('7.15alpha1', '7.15') is True
-    assert dev.version_is_lower('7.15', '7.15alpha1') is False
-
-
-def test_version_is_lower_beta_vs_stable(dev):
-    # beta < stable (release)
-    assert dev.version_is_lower('7.15beta1', '7.15') is True
-    assert dev.version_is_lower('7.15', '7.15beta1') is False
-
-
-def test_version_is_lower_same_beta(dev):
-    assert dev.version_is_lower('7.15beta1', '7.15beta2') is True
-    assert dev.version_is_lower('7.15beta2', '7.15beta1') is False
-
-
-def test_version_is_lower_equal(dev):
-    assert dev.version_is_lower('7.15', '7.15') is False
-
-
-def test_version_is_lower_third_segment(dev):
-    assert dev.version_is_lower('7.15.1', '7.15.2') is True
-    assert dev.version_is_lower('7.15.2', '7.15.1') is False
-    assert dev.version_is_lower('7.15.1', '7.15.1') is False
-
-
-def test_version_is_lower_rc_in_a(dev):
-    # 'rc1' has alpha chars but not 'alpha'/'beta' -> extra='0' branch
-    assert dev.version_is_lower('7.15rc1', '7.16') is True
-
-
-def test_version_is_lower_rc_in_b(dev):
-    # 'rc1' has alpha chars but not 'alpha'/'beta' -> extra='0' branch
-    assert dev.version_is_lower('7.14', '7.15rc1') is True
+@pytest.mark.parametrize(
+    'a,b,expected', [
+        ('6.99', '7.0', True),
+        ('7.0', '6.99', False),
+        ('7.14', '7.15', True),
+        ('7.15', '7.14', False),
+        ('7.15', '7.15', False),
+        ('7.15beta9', '7.15', True),
+        ('7.15', '7.15beta9', False),
+        ('7.15alpha1', '7.15', True),
+        ('7.15', '7.15alpha1', False),
+        ('7.15beta1', '7.15', True),
+        ('7.15', '7.15beta1', False),
+        ('7.15beta1', '7.15beta2', True),
+        ('7.15beta2', '7.15beta1', False),
+        ('7.15', '7.15', False),
+        ('7.15.1', '7.15.2', True),
+        ('7.15.2', '7.15.1', False),
+        ('7.15.1', '7.15.1', False),
+        ('7.15rc1', '7.16', True),
+        ('7.14', '7.15rc1', True),
+    ],
+)
+def test_version_is_lower(version_dev, a, b, expected):
+    assert version_dev.version_is_lower(a, b) is expected
 
 
 # ─── defensive client=None guard coverage ────────────────────────────────────
 
-def test_ssh_call_client_none_after_check(mock_conf):
-    """Cover line 392: raise when client is None despite _ssh_check pass."""
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
-    d.client = MagicMock()
-    with patch.object(d, '_ssh_check'):
-        d.client = None
+def test_ssh_call_client_none_after_check(disconnected_dev):
+    """Cover raise when client is None despite _ssh_check pass."""
+    with patch.object(disconnected_dev, '_ssh_check'):
         with pytest.raises(Exception):
-            d.ssh_call('cmd')
+            disconnected_dev.ssh_call('cmd')
 
 
-def test_upload_package_client_none_after_check(mock_conf, tmp_path):
-    """Cover line 792: raise when client is None despite _ssh_check pass."""
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
+def test_upload_package_client_none_after_check(disconnected_dev, tmp_path):
+    """Cover raise when client is None despite _ssh_check pass."""
     pkg = tmp_path / 'routeros-7.15.npk'
     pkg.write_bytes(b'fake')
-    d.client = MagicMock()
-    with patch.object(d, '_ssh_check'):
-        d.client = None
-        result = d._upload_package(pkg)
+    with patch.object(disconnected_dev, '_ssh_check'):
+        result = disconnected_dev._upload_package(pkg)
     assert result is False
 
 
-def test_backup_client_none_after_check(mock_conf):
-    """Cover line 112: raise when client is None inside backup try block."""
-    mock_logger = MagicMock(spec=Logger)
-    d = Device(
-        conf=mock_conf,
-        name='r',
-        address='10.0.0.1',
-        port=22,
-        username='admin',
-        update_type='online',
-        logger=mock_logger,
-    )
-    d.identity = 'myrouter'
-    d.client = MagicMock()
+def test_backup_client_none_after_check(disconnected_dev):
+    """Cover raise when client is None inside backup try block."""
+    disconnected_dev.identity = 'myrouter'
     backup_saved = ['Configuration backup saved\r']
-    with patch.object(d, '_ssh_check'):
-        with patch.object(d, 'ssh_call', return_value=backup_saved):
+    with patch.object(disconnected_dev, '_ssh_check'):
+        with patch.object(
+            disconnected_dev, 'ssh_call', return_value=backup_saved,
+        ):
             with patch.object(pathlib.Path, 'mkdir'):
-                d.client = None
-                result = d.backup()
+                result = disconnected_dev.backup()
     assert result is False

--- a/tests/userregistrator_test.py
+++ b/tests/userregistrator_test.py
@@ -1,0 +1,408 @@
+import pathlib
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import paramiko
+import pytest
+
+from mu.userregistrator import UserRegistrator
+
+
+@pytest.fixture
+def ur():
+    return UserRegistrator(
+        dev_name='testrouter',
+        dev_address='10.0.0.1',
+        dev_port=22,
+        username='scriptuser',
+        public_key_file='tests/data/test_key.pub',
+        public_key_owner='owner',
+    )
+
+
+@pytest.fixture
+def connected_ur(ur):
+    ur.client = MagicMock()
+    return ur
+
+
+# ─── __init__ ────────────────────────────────────────────────────────────────
+
+def test_init_basic():
+    ur = UserRegistrator(
+        dev_name='r',
+        dev_address='10.0.0.1',
+        dev_port=22,
+        username='admin',
+    )
+    assert ur.dev_name == 'r'
+    assert ur.dev_address == '10.0.0.1'
+    assert ur.dev_port == 22
+    assert ur.username == 'admin'
+    assert ur.public_key_file is None
+    assert ur.public_key_owner is None
+    assert ur.client is None
+
+
+def test_init_with_public_key_file():
+    ur = UserRegistrator(
+        dev_name='r',
+        dev_address='10.0.0.1',
+        dev_port=22,
+        username='admin',
+        public_key_file='mykey.pub',
+    )
+    assert isinstance(ur.public_key_file, pathlib.Path)
+    assert str(ur.public_key_file) == 'mykey.pub'
+
+
+def test_init_with_public_key_owner():
+    ur = UserRegistrator(
+        dev_name='r',
+        dev_address='10.0.0.1',
+        dev_port=22,
+        username='admin',
+        public_key_owner='alice',
+    )
+    assert ur.public_key_owner == 'alice'
+
+
+def test_init_public_key_file_non_string():
+    ur = UserRegistrator(
+        dev_name='r',
+        dev_address='10.0.0.1',
+        dev_port=22,
+        username='admin',
+        public_key_file=None,
+        public_key_owner=None,
+    )
+    assert ur.public_key_file is None
+    assert ur.public_key_owner is None
+
+
+# ─── ssh_connect ─────────────────────────────────────────────────────────────
+
+def test_ssh_connect_success(ur):
+    ur._admin_user = 'admin'
+    ur._admin_pwd = 'password'
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        ur.ssh_connect()
+    assert ur.client is mock_client
+    mock_client.connect.assert_called_once()
+
+
+def test_ssh_connect_auth_failure(ur):
+    ur._admin_user = 'admin'
+    ur._admin_pwd = 'wrongpassword'
+    with patch('paramiko.SSHClient') as mock_ssh_class:
+        mock_client = MagicMock()
+        mock_ssh_class.return_value = mock_client
+        mock_client.connect.side_effect = (
+            paramiko.AuthenticationException('fail')
+        )
+        with pytest.raises(paramiko.AuthenticationException):
+            ur.ssh_connect()
+
+
+# ─── ssh_close ───────────────────────────────────────────────────────────────
+
+def test_ssh_close_with_client(connected_ur):
+    saved_client = connected_ur.client
+    connected_ur.ssh_close()
+    saved_client.close.assert_called_once()
+    assert connected_ur.client is None
+
+
+def test_ssh_close_no_client(ur):
+    ur.client = None
+    ur.ssh_close()  # should not raise
+
+
+# ─── check_key_file ──────────────────────────────────────────────────────────
+
+def test_check_key_file_no_public_key_file(ur):
+    ur.public_key_file = None
+    ur.client = MagicMock()
+    result = ur.check_key_file()
+    assert result is False
+
+
+def test_check_key_file_no_client(ur):
+    ur.client = None
+    result = ur.check_key_file()
+    assert result is False
+
+
+def test_check_key_file_found(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        '0  mykey.pub  500\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.check_key_file()
+    assert result is True
+
+
+def test_check_key_file_not_found(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        '0  otherkey.pub  500\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.check_key_file()
+    assert result is False
+
+
+def test_check_key_file_exception(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    connected_ur.client.exec_command.side_effect = Exception('fail')
+    with pytest.raises(Exception):
+        connected_ur.check_key_file()
+
+
+def test_check_key_file_short_line(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    mock_stdout = MagicMock()
+    # Lines with <= 2 words are skipped
+    mock_stdout.readlines.return_value = ['short\n']
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.check_key_file()
+    assert result is False
+
+
+# ─── user_exists ─────────────────────────────────────────────────────────────
+
+def test_user_exists_no_client(ur):
+    ur.client = None
+    result = ur.user_exists()
+    assert result is False
+
+
+def test_user_exists_found(connected_ur):
+    connected_ur.username = 'scriptuser'
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        '0  scriptuser  full\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.user_exists()
+    assert result is True
+
+
+def test_user_exists_not_found(connected_ur):
+    connected_ur.username = 'scriptuser'
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        '0  otheruser  full\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.user_exists()
+    assert result is False
+
+
+def test_user_exists_exception(connected_ur):
+    connected_ur.client.exec_command.side_effect = Exception('fail')
+    with pytest.raises(Exception):
+        connected_ur.user_exists()
+
+
+def test_user_exists_short_line(connected_ur):
+    connected_ur.username = 'scriptuser'
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = ['short\n']
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    result = connected_ur.user_exists()
+    assert result is False
+
+
+# ─── register_user ───────────────────────────────────────────────────────────
+
+def test_register_user_no_client(ur):
+    ur.client = None
+    ur.register_user()  # should return without error
+
+
+def test_register_user_success(connected_ur):
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = []
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    with patch.object(connected_ur, 'user_exists', return_value=True):
+        connected_ur.register_user()
+
+
+def test_register_user_group_not_exist(connected_ur, capsys):
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        'input does not match any value of group\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    with patch.object(connected_ur, 'user_exists', return_value=False):
+        connected_ur.register_user()
+    captured = capsys.readouterr()
+    assert "Group full doesn't exist" in captured.out
+
+
+def test_register_user_not_created(connected_ur):
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = []
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    with patch.object(connected_ur, 'user_exists', return_value=False):
+        connected_ur.register_user()
+
+
+def test_register_user_exec_exception(connected_ur):
+    connected_ur.client.exec_command.side_effect = Exception('fail')
+    with pytest.raises(Exception):
+        connected_ur.register_user()
+
+
+# ─── upload_key_file ─────────────────────────────────────────────────────────
+
+def test_upload_key_file_no_client(ur):
+    ur.client = None
+    ur.upload_key_file()  # should return without error
+
+
+def test_upload_key_file_success(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    with patch('mu.userregistrator.SCPClient') as mock_scp_class:
+        mock_scp = MagicMock()
+        mock_scp_class.return_value.__enter__ = MagicMock(
+            return_value=mock_scp,
+        )
+        mock_scp_class.return_value.__exit__ = MagicMock(return_value=False)
+        connected_ur.upload_key_file()
+    mock_scp.put.assert_called_once_with(pathlib.Path('mykey.pub'))
+
+
+# ─── add_key_to_user ─────────────────────────────────────────────────────────
+
+def test_add_key_to_user_no_client(ur):
+    ur.client = None
+    ur.add_key_to_user()  # should return without error
+
+
+def test_add_key_to_user_no_public_key_file(connected_ur):
+    connected_ur.public_key_file = None
+    connected_ur.add_key_to_user()  # should return without error
+
+
+def test_add_key_to_user_success(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    connected_ur.public_key_owner = 'owner'
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = []
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    connected_ur.add_key_to_user()
+    connected_ur.client.exec_command.assert_called_once()
+
+
+def test_add_key_to_user_group_not_exist(connected_ur, capsys):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    connected_ur.public_key_owner = 'owner'
+    mock_stdout = MagicMock()
+    mock_stdout.readlines.return_value = [
+        'input does not match any value of group\n',
+    ]
+    connected_ur.client.exec_command.return_value = (
+        MagicMock(), mock_stdout, MagicMock(),
+    )
+    connected_ur.add_key_to_user()
+    captured = capsys.readouterr()
+    assert "Group full doesn't exist" in captured.out
+
+
+def test_add_key_to_user_exception(connected_ur):
+    connected_ur.public_key_file = pathlib.Path('mykey.pub')
+    connected_ur.public_key_owner = 'owner'
+    connected_ur.client.exec_command.side_effect = Exception('fail')
+    with pytest.raises(Exception):
+        connected_ur.add_key_to_user()
+
+
+# ─── run ─────────────────────────────────────────────────────────────────────
+
+def test_run_user_exists_key_file_present(ur):
+    with patch('builtins.input', return_value='admin'):
+        with patch('getpass.getpass', return_value='password'):
+            with patch.object(ur, 'ssh_connect'):
+                with patch.object(ur, 'user_exists', return_value=True):
+                    with patch.object(ur, 'check_key_file', return_value=True):
+                        with patch.object(ur, 'add_key_to_user'):
+                            with patch.object(ur, 'ssh_close'):
+                                with patch('time.sleep'):
+                                    result = ur.run()
+    assert result is True
+
+
+def test_run_user_not_exists_key_upload_success(ur):
+    with patch('builtins.input', return_value='admin'):
+        with patch('getpass.getpass', return_value='password'):
+            with patch.object(ur, 'ssh_connect'):
+                with patch.object(ur, 'user_exists', return_value=False):
+                    with patch.object(ur, 'register_user'):
+                        with patch.object(
+                            ur, 'check_key_file',
+                            side_effect=[False, True],
+                        ):
+                            with patch.object(ur, 'upload_key_file'):
+                                with patch.object(ur, 'add_key_to_user'):
+                                    with patch.object(ur, 'ssh_close'):
+                                        with patch('time.sleep'):
+                                            result = ur.run()
+    assert result is True
+
+
+def test_run_upload_fails(ur):
+    with patch('builtins.input', return_value='admin'):
+        with patch('getpass.getpass', return_value='password'):
+            with patch.object(ur, 'ssh_connect'):
+                with patch.object(ur, 'user_exists', return_value=True):
+                    with patch.object(
+                        ur, 'check_key_file',
+                        side_effect=[False, False],
+                    ):
+                        with patch.object(ur, 'upload_key_file'):
+                            with patch('time.sleep'):
+                                result = ur.run()
+    assert result is False
+
+
+def test_run_no_public_key_file_prompts(ur):
+    ur.public_key_file = None
+    ur.public_key_owner = None
+    inputs = iter(['admin', 'mykey.pub', 'alice'])
+    with patch('builtins.input', side_effect=inputs):
+        with patch('getpass.getpass', return_value='password'):
+            with patch.object(ur, 'ssh_connect'):
+                with patch.object(ur, 'user_exists', return_value=True):
+                    with patch.object(ur, 'check_key_file', return_value=True):
+                        with patch.object(ur, 'add_key_to_user'):
+                            with patch.object(ur, 'ssh_close'):
+                                with patch('time.sleep'):
+                                    result = ur.run()
+    assert result is True


### PR DESCRIPTION
Three new test files covering all previously untested paths:
- tests/device_extended_test.py: 110 tests for all Device methods (ssh_call, backup, update flows, firmware_update, reboot_and_wait, etc.)
- tests/userregistrator_test.py: 35 tests for UserRegistrator
- tests/configmanager_extended_test.py: 15 tests for remaining ConfigManager paths (fallback chains, deprecated keys, manual packages)